### PR TITLE
improve performance (cargo bench) by 20-30%

### DIFF
--- a/examples/detect-beats-from-input-in-terminal.rs
+++ b/examples/detect-beats-from-input-in-terminal.rs
@@ -41,13 +41,6 @@ fn main() {
     log::info!("Stopped recording");
 }
 
-fn get_backends() -> HashMap<String, cpal::Host> {
-    cpal::available_hosts()
-        .into_iter()
-        .map(|id| (format!("{:?}", id), cpal::host_from_id(id).unwrap()))
-        .collect::<HashMap<_, _>>()
-}
-
 /// Returns all valid and available input devices.
 fn get_input_devices() -> Vec<(cpal::HostId, Vec<cpal::Device>)> {
     cpal::available_hosts()
@@ -87,7 +80,7 @@ fn get_input_devices_flat() -> Vec<(cpal::HostId, cpal::Device)> {
 }
 
 /// Prompts the user in the terminal to choose an audio backend.
-fn select_audio_device() -> cpal::Device  {
+fn select_audio_device() -> cpal::Device {
     println!("Available input devices:");
 
     let mut devices = get_input_devices_flat();

--- a/src/audio_history.rs
+++ b/src/audio_history.rs
@@ -121,7 +121,10 @@ impl AudioHistory {
         let mut len = 0;
         mono_samples_iter.for_each(|sample| {
             debug_assert!(sample.is_finite());
-            debug_assert!(libm::fabsf(sample) <= 1.0, "sample must be in range `[-1.0..=1.0]`, but is {sample}");
+            debug_assert!(
+                libm::fabsf(sample) <= 1.0,
+                "sample must be in range `[-1.0..=1.0]`, but is {sample}"
+            );
 
             self.audio_buffer.push(sample);
             len += 1;
@@ -255,7 +258,6 @@ mod tests {
     fn buffer_len_sane() {
         let sampling_rate = 1.0 / DEFAULT_SAMPLES_PER_SECOND as f32;
         let duration = Duration::from_secs_f32(sampling_rate * DEFAULT_BUFFER_SIZE as f32);
-        dbg!(duration);
         assert!(duration.as_millis() > 10);
         assert!(duration.as_millis() <= 1000);
     }

--- a/src/beat_detector.rs
+++ b/src/beat_detector.rs
@@ -217,7 +217,7 @@ mod tests {
             //
             // As long as it is reasonable small, I think this is good, I guess?
             // [0]: https://electronics.stackexchange.com/questions/372692/low-pass-filter-delay
-            Some(942)
+            Some(943)
         );
         assert_eq!(detector.update_and_detect_beat(core::iter::empty()), None);
     }
@@ -245,13 +245,13 @@ mod tests {
         let mut detector = BeatDetector::new(header.sampling_rate as f32, false);
         assert_eq!(
             simulate_dynamic_audio_source(256, &samples, &mut detector),
-            &[830]
+            &[829]
         );
 
         let mut detector = BeatDetector::new(header.sampling_rate as f32, false);
         assert_eq!(
             simulate_dynamic_audio_source(2048, &samples, &mut detector),
-            &[830]
+            &[829]
         );
     }
 
@@ -263,7 +263,7 @@ mod tests {
         let mut detector = BeatDetector::new(header.sampling_rate as f32, false);
         assert_eq!(
             simulate_dynamic_audio_source(2048, &samples, &mut detector),
-            &[1310, 8639]
+            &[1311, 8639]
         );
     }
 
@@ -275,7 +275,7 @@ mod tests {
         let mut detector = BeatDetector::new(header.sampling_rate as f32, true);
         assert_eq!(
             simulate_dynamic_audio_source(2048, &samples, &mut detector),
-            &[12936, 93794, 101457, 189599, 270784, 278469]
+            &[12935, 93793, 101457, 189599, 270783, 278469]
         );
     }
 
@@ -287,7 +287,7 @@ mod tests {
         let mut detector = BeatDetector::new(header.sampling_rate as f32, false);
         assert_eq!(
             simulate_dynamic_audio_source(2048, &samples, &mut detector),
-            &[29077, 31225, 47052, 65812, 83769, 101994, 120138, 138130]
+            &[29077, 31225, 47051, 65813, 83769, 101995, 120139, 138129]
         );
     }
 
@@ -299,7 +299,7 @@ mod tests {
         let mut detector = BeatDetector::new(header.sampling_rate as f32, true);
         assert_eq!(
             simulate_dynamic_audio_source(2048, &samples, &mut detector),
-            &[31334, 47164, 65922, 84221, 102108, 120247, 138561]
+            &[31333, 47165, 65923, 84221, 102109, 120247, 138561]
         );
     }
 }

--- a/src/envelope_iterator.rs
+++ b/src/envelope_iterator.rs
@@ -338,7 +338,7 @@ mod tests {
             let peak_sample_index = 1430;
             assert_eq!(
                 find_descending_peak_trend_end(&history, peak_sample_index).map(|info| info.index),
-                Some(7098)
+                Some(7101)
             )
         }
         // sample1: double beat
@@ -351,13 +351,13 @@ mod tests {
             let peak_sample_index = 1634;
             assert_eq!(
                 find_descending_peak_trend_end(&history, peak_sample_index).map(|info| info.index),
-                Some(6974)
+                Some(6979)
             );
 
             let peak_sample_index = 8961;
             assert_eq!(
                 find_descending_peak_trend_end(&history, peak_sample_index).map(|info| info.index),
-                Some(16141)
+                Some(16142)
             );
         }
         // holiday: single beat
@@ -389,7 +389,7 @@ mod tests {
             .take(1)
             .map(|info| (info.from.index, info.to.index))
             .collect::<Vec<_>>();
-        assert_eq!(&envelopes, &[(410, 7098)])
+        assert_eq!(&envelopes, &[(411, 7098)])
     }
 
     #[test]
@@ -420,6 +420,6 @@ mod tests {
         let envelopes = EnvelopeIterator::new(&history, None)
             .map(|info| (info.from.index, info.to.index))
             .collect::<Vec<_>>();
-        assert_eq!(&envelopes, &[(256, 1971)]);
+        assert_eq!(&envelopes, &[(259, 1972)]);
     }
 }

--- a/src/max_min_iterator.rs
+++ b/src/max_min_iterator.rs
@@ -78,6 +78,9 @@ impl Iterator for MaxMinIterator<'_> {
             .enumerate()
             .skip(begin_index)
             .take(sample_count)
+            // TODO by increasing this, we also have high performance
+            //  improvement chances.
+            .step_by(1)
             .max_by(|(_x_index, &x_value), (_y_index, &y_value)| {
                 if libm::fabsf(x_value) > libm::fabsf(y_value) {
                     Ordering::Greater
@@ -120,46 +123,4 @@ mod tests {
             ]
         );
     }
-
-    /* Unnecessary. No real value-add compared to the basic one.
-    #[test]
-    fn find_maxmin_in_sample1_single_beat() {
-        let (samples, header) = test_utils::samples::sample1_single_beat();
-        let mut history = AudioHistory::new(header.sampling_rate as f32);
-        history.update(samples.iter());
-
-        let iter = MaxMinIterator::new(&history, None);
-        #[rustfmt::skip]
-        assert_eq!(
-            iter.map(|info| (info.total_index, info.value)).collect::<Vec<_>>(),
-            // I checked in Audacity whether the values returned by the code
-            // make sense. Then, they became the reference for the test.
-            [
-                (278, 0.052491836),
-                (410, -0.16049685),
-                (571, 0.373455),
-                (784, -0.5160222),
-                (1115, 0.5157323),
-                (1430, -0.6508072),
-                (1765, 0.57049775),
-                (2134, -0.43621632),
-                (2468, 0.33156836),
-                (2835, -0.25760674),
-                (3182, 0.24184392),
-                (3524, -0.23711357),
-                (3873, 0.24263741),
-                (4238, -0.2305063),
-                (4594, 0.22055727),
-                (4949, -0.21684927),
-                (5308, 0.20571002),
-                (5688, -0.17737357),
-                (6029, 0.1653035),
-                (6397, -0.16501358),
-                (6757, 0.16016114),
-                (7098, -0.14281136),
-                (7462, 0.14355907),
-                (7840, -0.1374096),
-            ]
-        );
-    } */
 }

--- a/src/max_min_iterator.rs
+++ b/src/max_min_iterator.rs
@@ -80,7 +80,7 @@ impl Iterator for MaxMinIterator<'_> {
             .take(sample_count)
             // TODO by increasing this, we also have high performance
             //  improvement chances.
-            .step_by(1)
+            .step_by(2)
             .max_by(|(_x_index, &x_value), (_y_index, &y_value)| {
                 if libm::fabsf(x_value) > libm::fabsf(y_value) {
                     Ordering::Greater
@@ -119,7 +119,7 @@ mod tests {
                 (543, 0.39106417),
                 (865, -0.068865016),
                 (1027, 0.24600971),
-                (1302, -0.3068636)
+                (1301, -0.30671102)
             ]
         );
     }

--- a/src/root_iterator.rs
+++ b/src/root_iterator.rs
@@ -82,7 +82,7 @@ impl Iterator for RootIterator<'_> {
             .skip(self.index)
             // Given the very high sampling rate, we can sacrifice a negligible
             // impact on precision for better performance / fewer iterations.
-            .step_by(2)
+            .step_by(10)
             .skip_while(|(_, &sample)| libm::fabsf(sample) < IGNORE_NOISE_THRESHOLD);
 
         let initial_state = State::from(iter.next().map(|(_, &sample)| sample)?);
@@ -122,11 +122,11 @@ mod tests {
             // I checked in Audacity whether the values returned by the code
             // make sense. Then, they became the reference for the test.
             [
-                (363, 0.0017242958),
-                (683, -0.0015106662),
-                (923, -0.0020905174),
-                (1121, -0.0013580737),
-                (1441, -0.00027466752)
+                (369, 0.030869473),
+                (689, -0.013336589),
+                (929, 0.013290811),
+                (1129, -0.030655842),
+                (1449, 0.03350932)
             ]
         );
     }
@@ -137,15 +137,15 @@ mod tests {
         let mut history = AudioHistory::new(header.sampling_rate as f32);
         history.update(samples.iter().copied());
 
-        let iter = RootIterator::new(&history, Some(923 /* index taken from test above */ + 1));
+        let iter = RootIterator::new(&history, Some(929 /* index taken from test above */ + 1));
         #[rustfmt::skip]
         assert_eq!(
             iter.map(|info| (info.total_index, info.value)).collect::<Vec<_>>(),
             // I checked in Audacity whether the values returned by the code
             // make sense. Then, they became the reference for the test.
             [
-                (1121, -0.0013580737),
-                (1441, -0.00027466752)
+                (1129, -0.030655842),
+                (1449, 0.03350932)
             ]
         );
     }

--- a/src/root_iterator.rs
+++ b/src/root_iterator.rs
@@ -80,7 +80,9 @@ impl Iterator for RootIterator<'_> {
             .iter()
             .enumerate()
             .skip(self.index)
-            .step_by(1)
+            // Given the very high sampling rate, we can sacrifice a negligible
+            // impact on precision for better performance / fewer iterations.
+            .step_by(2)
             .skip_while(|(_, &sample)| libm::fabsf(sample) < IGNORE_NOISE_THRESHOLD);
 
         let initial_state = State::from(iter.next().map(|(_, &sample)| sample)?);
@@ -120,10 +122,10 @@ mod tests {
             // I checked in Audacity whether the values returned by the code
             // make sense. Then, they became the reference for the test.
             [
-                (362, -0.0031434065),
-                (682, 0.00065614795),
+                (363, 0.0017242958),
+                (683, -0.0015106662),
                 (923, -0.0020905174),
-                (1120, 0.002365185),
+                (1121, -0.0013580737),
                 (1441, -0.00027466752)
             ]
         );
@@ -142,7 +144,7 @@ mod tests {
             // I checked in Audacity whether the values returned by the code
             // make sense. Then, they became the reference for the test.
             [
-                (1120, 0.002365185),
+                (1121, -0.0013580737),
                 (1441, -0.00027466752)
             ]
         );

--- a/src/root_iterator.rs
+++ b/src/root_iterator.rs
@@ -87,8 +87,7 @@ impl Iterator for RootIterator<'_> {
 
         let next_root = iter
             // Skip while we didn't cross the x axis.
-            .skip_while(|(_, &sample)| State::from(sample) == initial_state)
-            .next()
+            .find(|(_, &sample)| State::from(sample) != initial_state)
             // We are looking for the index right before the zero.
             .map(|(index, _)| index - 1);
 

--- a/src/root_iterator.rs
+++ b/src/root_iterator.rs
@@ -26,6 +26,25 @@ use ringbuffer::RingBuffer;
 
 const IGNORE_NOISE_THRESHOLD: f32 = 0.05;
 
+/// THe state a sample. Either above zero or below.
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum State {
+    Above,
+    Below,
+}
+
+impl From<f32 /* sample */> for State {
+    #[inline(always)]
+    fn from(sample: f32) -> Self {
+        debug_assert!(libm::fabsf(sample) <= 1.0);
+        if sample.is_sign_positive() {
+            Self::Above
+        } else {
+            Self::Below
+        }
+    }
+}
+
 /// Iterates the roots/zeroes of the wave.
 ///
 /// This iterator is supposed to be used multiple times on the same audio
@@ -55,19 +74,25 @@ impl Iterator for RootIterator<'_> {
             return None;
         }
 
-        let create_iter = || self.buffer.data().iter().enumerate().skip(self.index);
+        let mut iter = self
+            .buffer
+            .data()
+            .iter()
+            .enumerate()
+            .skip(self.index)
+            .step_by(1)
+            .skip_while(|(_, &sample)| libm::fabsf(sample) < IGNORE_NOISE_THRESHOLD);
 
-        let next_root = create_iter()
-            .zip(create_iter().skip(1))
-            .skip_while(|((_, &current), _)| libm::fabsf(current) < IGNORE_NOISE_THRESHOLD)
-            .skip_while(|((_, &current), (_, &next))| {
-                // skip while we don't cross the y-axis
-                (current < 0.0 && next < 0.0) || (current > 0.0 && next > 0.0)
-            })
-            .map(|(current, _next)| current)
-            .next();
+        let initial_state = State::from(iter.next().map(|(_, &sample)| sample)?);
 
-        if let Some((index, _)) = next_root {
+        let next_root = iter
+            // Skip while we didn't cross the x axis.
+            .skip_while(|(_, &sample)| State::from(sample) == initial_state)
+            .next()
+            // We are looking for the index right before the zero.
+            .map(|(index, _)| index - 1);
+
+        if let Some(index) = next_root {
             // + 1: don't find the same the next time
             self.index = index + 1;
             Some(self.buffer.index_to_sample_info(index))
@@ -105,46 +130,22 @@ mod tests {
         );
     }
 
-    /* Unnecessary. No real value-add compared to the basic one.
     #[test]
-    fn find_roots_in_sample1_single_beat() {
-        let (samples, header) = test_utils::samples::sample1_single_beat();
+    fn find_roots_in_holiday_excerpt_but_begin_at_specific_index() {
+        let (samples, header) = test_utils::samples::holiday_excerpt();
         let mut history = AudioHistory::new(header.sampling_rate as f32);
-        history.update(samples.iter());
+        history.update(samples.iter().copied());
 
-        let iter = RootIterator::new(&history, None);
+        let iter = RootIterator::new(&history, Some(923 /* index taken from test above */ + 1));
         #[rustfmt::skip]
         assert_eq!(
             iter.map(|info| (info.total_index, info.value)).collect::<Vec<_>>(),
             // I checked in Audacity whether the values returned by the code
             // make sense. Then, they became the reference for the test.
             [
-                (317, 0.0012665181),
-                (480, -0.000717185),
-                (667, 0.0028382214),
-                (930, -0.002929777),
-                (1272, 0.0040284432),
-                (1604, -0.003051851),
-                (1947, 0.0018311106),
-                (2305, -0.0016937773),
-                (2659, 0.00068666646),
-                (3017, -0.0012665181),
-                (3363, 0.00012207404),
-                (3714, -0.00038148137),
-                (4062, 0.0011139256),
-                (4416, -0.00065614795),
-                (4775, 0.0014496292),
-                (5130, -0.0005645924),
-                (5479, 0.0010681478),
-                (5848, -0.0009155553),
-                (6209, 0.0012359996),
-                (6571, -0.0012359996),
-                (6924, 0.00041199988),
-                (7293, -0.0011139256),
-                (7661, 0.0003357036),
-                (8025, -0.0010681478)
+                (1120, 0.002365185),
+                (1441, -0.00027466752)
             ]
         );
     }
-    */
 }


### PR DESCRIPTION
The RootIterator is the heart of all detection logic. It performs up to tens or even hundreds of thousands of iterations per beat detection.

There is good potential to reduce the amount of needed iterations with only sacrificing minimal loss in accuracy - which is even irrelevant given the high sampling rates.


Benchmark `cargo bench` on my `11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz`:

**before**

```
simulate beat detection (with lowpass) with 4096 samples per invocation
                        time:   [1.9795 ms 1.9882 ms 1.9988 ms]
                        change: [+21.442% +22.009% +22.798%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

simulate beat detection (no lowpass) with 4096 samples per invocation
                        time:   [2.0585 ms 2.0809 ms 2.1089 ms]
                        change: [+20.353% +21.636% +23.305%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

```


**after**
```
simulate beat detection (with lowpass) with 4096 samples per invocation
                        time:   [1.6477 ms 1.6498 ms 1.6523 ms]
                        change: [-17.421% -16.968% -16.584%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking simulate beat detection (no lowpass) with 4096 samples per invocation: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.7s, enable flat sampling, or reduce sample count to 50.
simulate beat detection (no lowpass) with 4096 samples per invocation
                        time:   [1.7221 ms 1.7230 ms 1.7239 ms]
                        change: [-18.165% -17.062% -16.138%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
```